### PR TITLE
Fix identation when word is UNKNOWN

### DIFF
--- a/src/tokenizer/Tokenizer.cpp
+++ b/src/tokenizer/Tokenizer.cpp
@@ -85,8 +85,8 @@ void Tokenizer::NextToken(Token & token)
   {
     lexeme += GetWord();
     token.SetType(GetTokenType(lexeme));
-      if(token.Match(UNKNOWN))
-    token.SetType(IDENTIFIER);
+    if(token.Match(UNKNOWN))
+      token.SetType(IDENTIFIER);
   }
     else
   {


### PR DESCRIPTION
When building an identifier, before it the word is UNKNOWN
